### PR TITLE
Set eslint `node` env to true

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,8 @@
   "root": true,
   "parser": "@typescript-eslint/parser",
   "env": {
-    "jest": true
+    "jest": true,
+    "node": true
   },
   "plugins": [
     "@typescript-eslint",

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line no-undef
 module.exports = {
   collectCoverage: false,
   collectCoverageFrom: ['src/**/*.ts', '!src/octokitTypes.ts', '!lib/**', '!node_modules/**'],


### PR DESCRIPTION
This fixes a `no-undef` eslint warning that was ignored.

See: https://eslint.org/docs/user-guide/configuring#specifying-environments