### PR TITLE
Reduce action's docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY package-lock.json .
 COPY tsconfig.json .
 COPY src ./src
 
-RUN npm install
-RUN npm run build
+RUN npm install --production
+RUN npx -p typescript@$(node -p "require('./package.json').devDependencies.typescript") tsc
 
 ENTRYPOINT ["node", "/lib/index.js"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1154,8 +1154,7 @@
     "@types/js-yaml": {
       "version": "3.12.3",
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.3.tgz",
-      "integrity": "sha512-otRe77JNNWzoVGLKw8TCspKswRoQToys4tuL6XYVBFxjgeM0RUrx7m3jkaTdxILxeGry3zM8mGYkGXMeQ02guA==",
-      "dev": true
+      "integrity": "sha512-otRe77JNNWzoVGLKw8TCspKswRoQToys4tuL6XYVBFxjgeM0RUrx7m3jkaTdxILxeGry3zM8mGYkGXMeQ02guA=="
     },
     "@types/json-schema": {
       "version": "7.0.4",
@@ -1166,8 +1165,7 @@
     "@types/lodash": {
       "version": "4.14.150",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.150.tgz",
-      "integrity": "sha512-kMNLM5JBcasgYscD9x/Gvr6lTAv2NVgsKtet/hm93qMyf/D1pt+7jeEZklKJKxMVmXjxbRVQQGfqDSfipYCO6w==",
-      "dev": true
+      "integrity": "sha512-kMNLM5JBcasgYscD9x/Gvr6lTAv2NVgsKtet/hm93qMyf/D1pt+7jeEZklKJKxMVmXjxbRVQQGfqDSfipYCO6w=="
     },
     "@types/minimist": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,6 @@
   "homepage": "https://github.com/johnmartel/organization-membership-action#readme",
   "devDependencies": {
     "@types/jest": "25.2.1",
-    "@types/js-yaml": "3.12.3",
-    "@types/lodash": "4.14.150",
     "@typescript-eslint/eslint-plugin": "2.32.0",
     "@typescript-eslint/parser": "2.32.0",
     "eslint": "6.8.0",
@@ -52,6 +50,8 @@
     "@octokit/rest": "17.9.0",
     "@octokit/types": "2.16.0",
     "@octokit/webhooks": "7.5.0",
+    "@types/js-yaml": "3.12.3",
+    "@types/lodash": "4.14.150",
     "actions-toolkit": "4.0.0",
     "js-yaml": "3.13.1",
     "lodash": "4.17.15",


### PR DESCRIPTION
By installing only the production dependencies and running `tsc` using
npx instead of installing it to the image, the size dropped from 254MB
to 112MB.

See: #11