### PR TITLE
Ignore empty members file

### DIFF
--- a/.mdlrc
+++ b/.mdlrc
@@ -1,2 +1,1 @@
 style "./.markdown.style.rb"
-

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ members:
 
 The roles are defined in the [API documentation](https://developer.github.com/v3/orgs/members/#parameters-1).
 
+In order to prevent accidental deletion of all organization members, this action will ignore an empty members file and
+exit with failure.
+
 ## Building
 
 ```shell script

--- a/__tests__/fixtures/membersFiles.ts
+++ b/__tests__/fixtures/membersFiles.ts
@@ -1,0 +1,21 @@
+export const EMPTY_FILE = '';
+
+export const INVALID_FILE = `
+public_members:
+  - login: johnmartel
+    role: admin
+  - login: sebasrobert
+    role: member
+`;
+
+export const VALID_FILE = `
+members:
+  - login: johnmartel
+    role: admin
+  - login: sebasrobert
+    role: member
+`;
+
+export const VALID_FILE_WITH_EMPTY_MEMBERS = `
+members:
+`;

--- a/__tests__/membersFile.test.ts
+++ b/__tests__/membersFile.test.ts
@@ -1,22 +1,7 @@
 import 'jest-extended';
 import MembersFile from '../src/membersFile';
 import { MemberRole, OrganizationMember } from '../src/organizationMember';
-
-const VALID_FILE = `
-members:
-  - login: johnmartel
-    role: admin
-  - login: sebasrobert
-    role: member
-`;
-
-const INVALID_FILE = `
-public_members:
-  - login: johnmartel
-    role: admin
-  - login: sebasrobert
-    role: member
-`;
+import { EMPTY_FILE, INVALID_FILE, VALID_FILE, VALID_FILE_WITH_EMPTY_MEMBERS } from './fixtures/membersFiles';
 
 describe('MembersFile test suite', () => {
   let membersFile: MembersFile;
@@ -42,6 +27,38 @@ describe('MembersFile test suite', () => {
 
       it('should be an empty array', () => {
         expect(membersFile.allMembers).toBeEmpty();
+      });
+    });
+  });
+
+  describe('isEmpty', () => {
+    describe('given a file with members', () => {
+      beforeEach(() => {
+        membersFile = new MembersFile(VALID_FILE);
+      });
+
+      it('should return false', () => {
+        expect(membersFile.isEmpty()).toBe(false);
+      });
+    });
+
+    describe('given an empty members array', () => {
+      beforeEach(() => {
+        membersFile = new MembersFile(VALID_FILE_WITH_EMPTY_MEMBERS);
+      });
+
+      it('should return false', () => {
+        expect(membersFile.isEmpty()).toBe(true);
+      });
+    });
+
+    describe('given an empty file', () => {
+      beforeEach(() => {
+        membersFile = new MembersFile(EMPTY_FILE);
+      });
+
+      it('should return false', () => {
+        expect(membersFile.isEmpty()).toBe(true);
       });
     });
   });

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,4 +15,5 @@ module.exports = {
   reporters: ['default', 'jest-junit'],
   setupFilesAfterEnv: ['jest-extended'],
   testEnvironment: 'node',
+  testPathIgnorePatterns: ['/fixtures/'],
 };

--- a/src/action.ts
+++ b/src/action.ts
@@ -10,6 +10,11 @@ async function synchronizeOrganizationMembership(
   organization: GithubOrganization,
   membersFile: MembersFile,
 ): Promise<void> {
+  if (membersFile.isEmpty()) {
+    tools.exit.failure('Empty members file: this action will not let you remove ALL members from this organization');
+    return;
+  }
+
   tools.log('Invite new members or update existing members');
   const addOrUpdateMembershipResults = await organization.inviteNewMembers(membersFile.allMembers);
   addOrUpdateMembershipResults.printResults(tools.log);

--- a/src/membersFile.ts
+++ b/src/membersFile.ts
@@ -7,7 +7,7 @@ export default class MembersFile {
   static readonly FILENAME: string = '.github/organization/members.yml';
 
   private file: {
-    members: MemberFileEntry[];
+    members: MemberFileEntry[] | undefined;
   };
 
   constructor(contents: string) {
@@ -15,10 +15,14 @@ export default class MembersFile {
   }
 
   get allMembers(): OrganizationMember[] {
-    if (!this.file.members) {
+    if (!this.file?.members) {
       return [];
     }
 
     return this.file.members.map((member) => new OrganizationMember(member.login, member.role));
+  }
+
+  isEmpty(): boolean {
+    return this.allMembers.length === 0;
   }
 }


### PR DESCRIPTION
To avoid accidentally removing all organization members, this action
will ignore an empty members file and exit with a failure.

Closes #25.